### PR TITLE
improve performance by using wc -l instead of awk

### DIFF
--- a/mal-dnssearch.sh
+++ b/mal-dnssearch.sh
@@ -109,7 +109,7 @@ if [ "$DOWNLOAD" != "NO" ]; then
 fi
 
 if [ -f ${MALHOSTFILE:-$MALFILEDEFAULT} ]; then
-	total=$(sed -e '/^$/d' -e '/^#/d' < ${MALHOSTFILE:-$MALFILEDEFAULT} | awk 'END { print NR }')
+	total=$(sed -e '/^$/d' -e '/^#/d' < ${MALHOSTFILE:-$MALFILEDEFAULT} | wc -l)
 else
 	echo -e "\n${ORANGE}[${END}${RED}*${END}${ORANGE}]${END} File doesn't exist (Is it in the current working directory?)..Exiting."
 	exit 1


### PR DESCRIPTION
loading and running awk is more time and resources consuming than wc:

time sed -e '/^$/d' -e '/^#/d' < malhosts.txt | awk 'END { print NR }'
2446
sed -e '/^$/d' -e '/^#/d' < malhosts.txt  0,00s user 0,00s system 51% cpu 0,008 total
awk 'END { print NR }'  0,00s user 0,00s system 55% cpu 0,007 total

time sed -e '/^$/d' -e '/^#/d' < malhosts.txt | wc -l
2446
sed -e '/^$/d' -e '/^#/d' < malhosts.txt  0,00s user 0,00s system 55% cpu 0,007 total
wc -l  0,00s user 0,00s system 0% cpu 0,006 total
