### PR TITLE
GeoIP Lookup Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Type:      |    Description:
 argus      |    ARGUS file (requires user data i.e. setting ARGUS_CAPTURE_DATA_LEN)
 bind       |    ISC's BIND query log file
 bro        |    BRO-IDS dns.log file
-custom|ip  -    Custom file - IP addresses, one per line.
-custom|dns -    Custom file - DNS (with one DNS name per line w/o trailing FQDN dot)
+custom-ip  |	Custom file - IP addresses, one per line.
+custom-dns |	Custom file - DNS (with one DNS name per line w/o trailing FQDN dot)
 hosts      |    /etc/hosts file
 httpry     |    HttPry log file
 passivedns |    PassiveDNS log file

--- a/mal-dnssearch.sh
+++ b/mal-dnssearch.sh
@@ -204,9 +204,13 @@ compare()
     [[ ${VERBOSELOG:-0} -eq 1 ]] && echo "---log: $host"
     if [[ ${bad_hosts[$host]} ]]; then
       if [[ "$GEO" = "1" ]]; then
-        $GEORESULT="$(geoiplookup $host | sed -e 's/GeoIP Country Edition://g')"
-	echo -e "${ORANGE}[${END}${RED}+${END}${ORANGE}]${END} ${RED}Found${END} - host '"${ORANGE}$host${END}"' matches, country is$GEORESULT"
-
+        if command -v geoiplookup >/dev/null 2>&1; then
+          $GEORESULT="$(geoiplookup $host | sed -e 's/GeoIP Country Edition://g')"
+	  echo -e "${ORANGE}[${END}${RED}+${END}${ORANGE}]${END} ${RED}Found${END} - host '"${ORANGE}$host${END}"' matches, country is$GEORESULT"
+        else
+	  echo -e "geoiplookup not available! Install geoip-bin."
+	  exit 1
+      fi
       else
         echo -e "${ORANGE}[${END}${RED}+${END}${ORANGE}]${END} ${RED}Found${END} - host '"${ORANGE}$host${END}"' matches "
       fi

--- a/mal-dnssearch.sh
+++ b/mal-dnssearch.sh
@@ -69,7 +69,8 @@ Default mal-list: http://secure.mayhemiclabs.com/malhosts/malhosts.txt
       Processing Options:
 	-h      help (this message)
 	-F      insert firewall rules (blocks) e.g. iptables,pf,ipfw
-        -l      Log stdout & stderr to <file>
+	-G	Perform GeoIP lookup for reportedly malicious IPs
+	-l      Log stdout & stderr to <file>
 	-N 	Skip file download
 	-p 	Print parsed mal-ware list to stdout e.g. \`\`-M ciarmy -p | prog''
 	-v	Verbose, print each line line from malware list
@@ -202,7 +203,13 @@ compare()
   do
     [[ ${VERBOSELOG:-0} -eq 1 ]] && echo "---log: $host"
     if [[ ${bad_hosts[$host]} ]]; then
-      echo -e "${ORANGE}[${END}${RED}+${END}${ORANGE}]${END} ${RED}Found${END} - host '"${ORANGE}$host${END}"' matches "
+      if [[ "$GEO" = "1" ]]; then
+        $GEORESULT="$(geoiplookup $host | sed -e 's/GeoIP Country Edition://g')"
+	echo -e "${ORANGE}[${END}${RED}+${END}${ORANGE}]${END} ${RED}Found${END} - host '"${ORANGE}$host${END}"' matches, country is$GEORESULT"
+
+      else
+        echo -e "${ORANGE}[${END}${RED}+${END}${ORANGE}]${END} ${RED}Found${END} - host '"${ORANGE}$host${END}"' matches "
+      fi
       let found++
       [[ "$FWTRUE" = "1" ]] && ipblock
     fi
@@ -223,6 +230,7 @@ LOG_SET=0
 FILE_SET=0
 PIPE=0
 DNS=0
+GEO=0
 ARGUS=0
 BIND=0
 BRODNS=0
@@ -250,7 +258,7 @@ WHITE="$(tput setaf 7)"
 bash_check
 
 # option and argument handling
-while getopts "hf:F:l:pM:NT:vVw:" OPTION
+while getopts "hf:F:Gl:pM:NT:vVw:" OPTION
 do
 case $OPTION in
   F)
@@ -260,6 +268,9 @@ case $OPTION in
   f)
     FILE="$OPTARG"
     FILE_SET=1
+    ;;
+  G)
+    GEO=1
     ;;
   h)
     usage

--- a/mal-dnssearch.sh
+++ b/mal-dnssearch.sh
@@ -205,8 +205,8 @@ compare()
     if [[ ${bad_hosts[$host]} ]]; then
       if [[ "$GEO" = "1" ]]; then
         if command -v geoiplookup >/dev/null 2>&1; then
-          $GEORESULT="$(geoiplookup $host | sed -e 's/GeoIP Country Edition://g')"
-	  echo -e "${ORANGE}[${END}${RED}+${END}${ORANGE}]${END} ${RED}Found${END} - host '"${ORANGE}$host${END}"' matches, country is$GEORESULT"
+          #$GEORESULT="$(geoiplookup $host | sed -n 1p | sed -e 's/GeoIP Country Edition://g')"
+	  echo -e "${ORANGE}[${END}${RED}+${END}${ORANGE}]${END} ${RED}Found${END} - host '"${ORANGE}$host${END}"' matches, and is located in$(geoiplookup $host | sed -n 1p | sed -e 's/GeoIP Country Edition://g' | sed 's/.*,//')"
         else
 	  echo -e "geoiplookup not available! Install geoip-bin."
 	  exit 1


### PR DESCRIPTION
Delivers the enhancement requested in issue #9 by displaying the country of origin for a suspected malicious IP.

Checks to make sure the geoiplookup command is present, and if not describes which package to install.
![screen shot 2017-07-25 at 10 30 41 am](https://user-images.githubusercontent.com/8700702/28581696-8d5941f0-7128-11e7-937b-320af18fbb9a.png)
